### PR TITLE
Support multiple spi ports

### DIFF
--- a/wiringPi/wiringPiSPI.c
+++ b/wiringPi/wiringPiSPI.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <string.h>
+#include <stdio.h>
 #include <sys/ioctl.h>
 #include <asm/ioctl.h>
 #include <linux/spi/spidev.h>
@@ -39,8 +40,6 @@
 // The SPI bus parameters
 //	Variables as they need to be passed as pointers later on
 
-static const char       *spiDev0  = "/dev/spidev0.0" ;
-static const char       *spiDev1  = "/dev/spidev1.0" ;
 static const uint8_t     spiBPW   = 8 ;
 static const uint16_t    spiDelay = 0 ;
 
@@ -97,14 +96,22 @@ int wiringPiSPIDataRW (int channel, unsigned char *data, int len)
  *********************************************************************************
  */
 
-int wiringPiSPISetupMode (int channel, int speed, int mode)
+void getDevice(char* spidev, int channel, int port) {
+    sprintf(spidev, "/dev/spidev/%i.%i", channel, port);
+}
+
+int wiringPiSPISetupMode (int channel, int speed, int mode, int port)
 {
   int fd ;
 
   mode    &= 3 ;	// Mode is 0, 1, 2 or 3
   channel &= 1 ;	// Channel is 0 or 1
 
-  if ((fd = open (channel == 0 ? spiDev0 : spiDev1, O_RDWR)) < 0)
+  static char spidev[14];
+
+  getDevice(spidev, channel, port);
+
+  if ((fd = open (spidev, O_RDWR)) < 0)
     return wiringPiFailure (WPI_ALMOST, "Unable to open SPI device: %s\n", strerror (errno)) ;
 
   spiSpeeds [channel] = speed ;

--- a/wiringPi/wiringPiSPI.c
+++ b/wiringPi/wiringPiSPI.c
@@ -100,7 +100,7 @@ void getDevice(char* spidev, int channel, int port) {
     sprintf(spidev, "/dev/spidev/%i.%i", channel, port);
 }
 
-int wiringPiSPISetupMode (int channel, int speed, int mode, int port)
+int wiringPiSPISetupMode (int channel, int port, int speed, int mode)
 {
   int fd ;
 
@@ -140,5 +140,5 @@ int wiringPiSPISetupMode (int channel, int speed, int mode, int port)
 
 int wiringPiSPISetup (int channel, int speed)
 {
-  return wiringPiSPISetupMode (channel, speed, 0) ;
+  return wiringPiSPISetupMode (channel, 0, speed, 0) ;
 }

--- a/wiringPi/wiringPiSPI.c
+++ b/wiringPi/wiringPiSPI.c
@@ -97,7 +97,7 @@ int wiringPiSPIDataRW (int channel, unsigned char *data, int len)
  */
 
 void getDevice(char* spidev, int channel, int port) {
-    sprintf(spidev, "/dev/spidev/%i.%i", channel, port);
+    sprintf(spidev, "/dev/spidev%i.%i", channel, port);
 }
 
 int wiringPiSPISetupMode (int channel, int port, int speed, int mode)
@@ -110,6 +110,7 @@ int wiringPiSPISetupMode (int channel, int port, int speed, int mode)
   static char spidev[14];
 
   getDevice(spidev, channel, port);
+  printf("Opening device %s\n", spidev); 
 
   if ((fd = open (spidev, O_RDWR)) < 0)
     return wiringPiFailure (WPI_ALMOST, "Unable to open SPI device: %s\n", strerror (errno)) ;

--- a/wiringPi/wiringPiSPI.h
+++ b/wiringPi/wiringPiSPI.h
@@ -28,7 +28,7 @@ extern "C" {
 
 int wiringPiSPIGetFd     (int channel) ;
 int wiringPiSPIDataRW    (int channel, unsigned char *data, int len) ;
-int wiringPiSPISetupMode (int channel, int speed, int mode, int port=0) ;
+int wiringPiSPISetupMode (int channel, int port, int speed, int mode) ;
 int wiringPiSPISetup     (int channel, int speed) ;
 
 #ifdef __cplusplus

--- a/wiringPi/wiringPiSPI.h
+++ b/wiringPi/wiringPiSPI.h
@@ -28,7 +28,7 @@ extern "C" {
 
 int wiringPiSPIGetFd     (int channel) ;
 int wiringPiSPIDataRW    (int channel, unsigned char *data, int len) ;
-int wiringPiSPISetupMode (int channel, int speed, int mode) ;
+int wiringPiSPISetupMode (int channel, int speed, int mode, int port=0) ;
 int wiringPiSPISetup     (int channel, int speed) ;
 
 #ifdef __cplusplus


### PR DESCRIPTION
As discussed in #10, here is a PR that supports multiple SPI devices. I did change the API to add the "port" to `wiringPiSPISetupMode`. I could instead make a new function as well, but the `wiringPiSetup` remains unchanged.

This works on my OrangePi Zero using Armbian buster (mainline kernel 5.4.20). 

I was using the following `/boot/armbianEnv.txt` to get multiple spi ports:
```
verbosity=1
logo=disabled
console=serial
disp_mode=none
overlay_prefix=sun8i-h3
overlays=spi-spidev uart1
param_spidev_spi_bus=1
rootdev=UUID=48c1e88a-b408-42ec-9d6c-9aaacd147312
rootfstype=ext4
user_overlays= spi-add-cs1+2
usbstoragequirks=0x2537:0x1066:u,0x2537:0x1068:u
```

This is my `spi-add-cs1+2.dts` which sets PA10 and PA02 as additional CS pins for SPI1 (channel 1), in addition to the hardware CS pin already there. 

```
/dts-v1/;
/plugin/;

/ {
    compatible = "allwinner,sun8i-h3";

    fragment@0 {
        target = <&pio>;
        __overlay__ {

            spi1_cs1: spi1_cs1 {
                pins = "PA10";
                function = "gpio_out";
                output-high;
            };

            spi1_cs2: spi1_cs2 {
                pins = "PA02";
                function = "gpio_out";
                output-high;
            };
        };
    };


    fragment@1 {
        target = <&spi1>;
        __overlay__ {
            pinctrl-names = "default", "default", "default";
            pinctrl-1 = <&spi1_cs1 &spi1_cs2>;
            cs-gpios = <0>, <&pio 0 10 0>, <&pio 0 2 0>; /* PA10 + PA02 */
            #address-cells = <1>;
            #size-cells = <0>;
            status = "okay";

            spidev@0 {
                reg = <0>; /* Chip Select 0 */
                compatible = "spidev";
                spi-max-frequency = <32000000>;
                status = "okay";
            };

            spidev@1 {
                reg = <1>; /* Chip Select 1 */
                compatible = "spidev";
                spi-max-frequency = <32000000>;
                status = "okay";
            };
            spidev@2 {
                reg = <2>; /* Chip Select 2 */
                compatible = "spidev";
                spi-max-frequency = <32000000>;
                status = "okay";
            };
        };
    };

};
```

