### PR TITLE
Add support for debian building

### DIFF
--- a/People
+++ b/People
@@ -31,3 +31,7 @@ Andre Crone
 
 Rik Teerling
   Pointing out some silly mistooks in the I2C code...
+
+Dolf Andringa
+  Support for multiple SpiDev devices/ports
+  Debian build support

--- a/build
+++ b/build
@@ -115,14 +115,19 @@ fi
 
 if [ x$1 = "xdebian" ]; then
   here=`pwd`
+  echo "removing old libs"
   cd debian-template/wiringPi
   rm -rf usr
+  echo "building wiringPi"
   cd $here/wiringPi
   make install-deb
+  echo "building devLib"
   cd $here/devLib
   make install-deb INCLUDE='-I. -I../wiringPi'
+  echo "building gpio"
   cd $here/gpio
   make install-deb INCLUDE='-I../wiringPi -I../devLib' LDFLAGS=-L../debian-template/wiringPi/usr/lib
+  echo "Building deb package"
   cd $here/debian-template
   fakeroot dpkg-deb --build wiringPi
   mv wiringPi.deb  wiringpi-`cat $here/VERSION`-1.deb

--- a/debian-template/wiringPi/DEBIAN/control
+++ b/debian-template/wiringPi/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: wiringPi
+Version: 2.46
+Section: libraries
+Priority: optional
+Architecture: armhf
+Depends: libc6
+Maintainer: Boby Lee <leeboby@aliyun.com>
+Description: The wiringPi libraries for the OrangePi, headers and gpio command
+  Libraries to allow GPIO access on a Raspberry Pi from C and C++
+  and BASIC programs as well as from the command-line

--- a/debian-template/wiringPi/DEBIAN/postinst
+++ b/debian-template/wiringPi/DEBIAN/postinst
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+/bin/chown root.root	/usr/bin/gpio
+/bin/chmod 4755		/usr/bin/gpio
+/sbin/ldconfig

--- a/debian-template/wiringPi/DEBIAN/postrm
+++ b/debian-template/wiringPi/DEBIAN/postrm
@@ -1,0 +1,2 @@
+#!/bin/sh
+/sbin/ldconfig

--- a/devLib/Makefile
+++ b/devLib/Makefile
@@ -25,6 +25,9 @@ VERSION=$(shell cat ../VERSION)
 DESTDIR?=/usr
 PREFIX?=/local
 
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
+
 LDCONFIG?=ldconfig
 
 ifneq ($V,1)
@@ -108,12 +111,12 @@ install-static:	$(STATIC)
 .PHONY:	install-deb
 install-deb:	$(DYNAMIC)
 	$Q echo "[Install Headers: deb]"
-	$Q install -m 0755 -d							~/wiringPi/debian-template/wiringPi/usr/include
-	$Q install -m 0644 $(HEADERS)						~/wiringPi/debian-template/wiringPi/usr/include
+	$Q install -m 0755 -d							$(CURDIR)/../debian-template/wiringPi/usr/include
+	$Q install -m 0644 $(HEADERS)						$(CURDIR)/../debian-template/wiringPi/usr/include
 	$Q echo "[Install Dynamic Lib: deb]"
-	install -m 0755 -d							~/wiringPi/debian-template/wiringPi/usr/lib
-	install -m 0755 libwiringPiDev.so.$(VERSION)				~/wiringPi/debian-template/wiringPi/usr/lib/libwiringPiDev.so.$(VERSION)
-	ln -sf ~/wiringPi/debian-template/wiringPi/usr/lib/libwiringPiDev.so.$(VERSION)	~/wiringPi/debian-template/wiringPi/usr/lib/libwiringPiDev.so
+	install -m 0755 -d							$(CURDIR)/../debian-template/wiringPi/usr/lib
+	install -m 0755 libwiringPiDev.so.$(VERSION)				$(CURDIR)/../debian-template/wiringPi/usr/lib/libwiringPiDev.so.$(VERSION)
+	ln -sf $(CURDIR)/../debian-template/wiringPi/usr/lib/libwiringPiDev.so.$(VERSION)	$(CURDIR)/../debian-template/wiringPi/usr/lib/libwiringPiDev.so
 
 .PHONY:	uninstall
 uninstall:

--- a/devLib/Makefile
+++ b/devLib/Makefile
@@ -25,9 +25,6 @@ VERSION=$(shell cat ../VERSION)
 DESTDIR?=/usr
 PREFIX?=/local
 
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
-
 LDCONFIG?=ldconfig
 
 ifneq ($V,1)

--- a/gpio/Makefile
+++ b/gpio/Makefile
@@ -218,10 +218,10 @@ endif
 .PHONY:	install-deb
 install-deb:	gpio
 	$Q echo "[Install: deb]"
-	$Q install -m 0755 -d							~/wiringPi/debian-template/wiringPi/usr/bin
-	$Q install -m 0755 gpio							~/wiringPi/debian-template/wiringPi/usr/bin
-	$Q install -m 0755 -d							~/wiringPi/debian-template/wiringPi/usr/share/man/man1
-	$Q install -m 0644 gpio.1						~/wiringPi/debian-template/wiringPi/usr/share/man/man1
+	$Q install -m 0755 -d							$(CURDIR)/../debian-template/wiringPi/usr/bin
+	$Q install -m 0755 gpio							$(CURDIR)/../debian-template/wiringPi/usr/bin
+	$Q install -m 0755 -d							$(CURDIR)/../debian-template/wiringPi/usr/share/man/man1
+	$Q install -m 0644 gpio.1						$(CURDIR)/../debian-template/wiringPi/usr/share/man/man1
 
 .PHONY:	uninstall
 uninstall:

--- a/wiringPi/Makefile
+++ b/wiringPi/Makefile
@@ -25,9 +25,6 @@ VERSION=$(shell cat ../VERSION)
 DESTDIR?=/usr
 PREFIX?=/local
 
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
-
 LDCONFIG?=ldconfig
 
 ifneq ($V,1)

--- a/wiringPi/Makefile
+++ b/wiringPi/Makefile
@@ -25,6 +25,9 @@ VERSION=$(shell cat ../VERSION)
 DESTDIR?=/usr
 PREFIX?=/local
 
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
+
 LDCONFIG?=ldconfig
 
 ifneq ($V,1)
@@ -204,6 +207,7 @@ OBJ	=	$(SRC:.c=.o)
 
 all:		$(DYNAMIC)
 
+
 .PHONY:	static
 static:	
 		$Q cat noMoreStatic
@@ -242,12 +246,12 @@ install:	$(DYNAMIC)
 .PHONY:	install-deb
 install-deb:	$(DYNAMIC)
 	$Q echo "[Install Headers: deb]"
-	$Q install -m 0755 -d							~/wiringPi/debian-template/wiringPi/usr/include
-	$Q install -m 0644 $(HEADERS)						~/wiringPi/debian-template/wiringPi/usr/include
+	$Q install -m 0755 -d							$(CURDIR)/../debian-template/wiringPi/usr/include
+	$Q install -m 0644 $(HEADERS)						$(CURDIR)/../debian-template/wiringPi/usr/include
 	$Q echo "[Install Dynamic Lib: deb]"
-	install -m 0755 -d							~/wiringPi/debian-template/wiringPi/usr/lib
-	install -m 0755 libwiringPi.so.$(VERSION)				~/wiringPi/debian-template/wiringPi/usr/lib/libwiringPi.so.$(VERSION)
-	ln -sf ~/wiringPi/debian-template/wiringPi/usr/lib/libwiringPi.so.$(VERSION)	~/wiringPi/debian-template/wiringPi/usr/lib/libwiringPi.so
+	install -m 0755 -d							$(CURDIR)/../debian-template/wiringPi/usr/lib
+	install -m 0755 libwiringPi.so.$(VERSION)				$(CURDIR)/../debian-template/wiringPi/usr/lib/libwiringPi.so.$(VERSION)
+	ln -sf $(CURDIR)/../debian-template/wiringPi/usr/lib/libwiringPi.so.$(VERSION)	$(CURDIR)/../debian-template/wiringPi/usr/lib/libwiringPi.so
 
 .PHONY:	uninstall
 uninstall:

--- a/wiringPiD/Makefile
+++ b/wiringPiD/Makefile
@@ -25,9 +25,6 @@
 DESTDIR?=/usr
 PREFIX?=/local
 
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
-
 ifneq ($V,1)
 Q ?= @
 endif

--- a/wiringPiD/Makefile
+++ b/wiringPiD/Makefile
@@ -25,6 +25,9 @@
 DESTDIR?=/usr
 PREFIX?=/local
 
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
+
 ifneq ($V,1)
 Q ?= @
 endif
@@ -78,10 +81,10 @@ install: wiringpid
 .PHONY:	install-deb
 install-deb:	gpio
 	$Q echo "[Install: deb]"
-	$Q install -m 0755 -d							~/wiringPi/debian-template/wiringPi/usr/bin
-	$Q install -m 0755 gpio							~/wiringPi/debian-template/wiringPi/usr/bin
-	$Q install -m 0755 -d							~/wiringPi/debian-template/wiringPi/man/man1
-	$Q install -m 0644 gpio.1						~/wiringPi/debian-template/wiringPi/man/man1
+	$Q install -m 0755 -d							$(CURDIR)/../debian-template/wiringPi/usr/bin
+	$Q install -m 0755 gpio							$(CURDIR)/../debian-template/wiringPi/usr/bin
+	$Q install -m 0755 -d							$(CURDIR)/../debian-template/wiringPi/man/man1
+	$Q install -m 0644 gpio.1						$(CURDIR)/../debian-template/wiringPi/man/man1
 
 .PHONY:	uninstall
 uninstall:


### PR DESCRIPTION
As described in #12  I added support for building debian packages. You can build them by issuing `./build debian` in the wiringOP directory. This should create the `.deb` file in `./debian-template`