### PR TITLE
wiringpi Makefile verbosity

### DIFF
--- a/wiringPi/Makefile
+++ b/wiringPi/Makefile
@@ -45,6 +45,7 @@ CFLAGS	= $(DEBUG) $(DEFS) -Wformat=2 -Wextra -Winline $(INCLUDE) -pipe -fPIC
 LIBS    = -lm -lpthread -lrt -lcrypt
 
 ifeq ($(PLATFORM),)
+  $(warning	WARNING: PLATFORM is not set!)
   #PLATFORM = OrangePi_2G-IOT
   #PLATFORM = OrangePi_PC2
   #PLATFORM = OrangePi_PRIME
@@ -204,6 +205,7 @@ OBJ	=	$(SRC:.c=.o)
 
 all:		$(DYNAMIC)
 
+$(info 	building for platform $(PLATFORM))
 
 .PHONY:	static
 static:	


### PR DESCRIPTION
Had this compiled for a yocto image not using the provided build command. I didn't read the commands carefully enough and built for the wrong $PLATFORM repeatedly and wondered why it didn't behave properly on the target. Some added verbosity could have probably saved some time. 