### PR TITLE
Use proper i2c port on OrangePI

### DIFF
--- a/wiringPi/wiringPiI2C.c
+++ b/wiringPi/wiringPiI2C.c
@@ -224,7 +224,7 @@ int wiringPiI2CSetup (const int devId)
 
   rev = piGpioLayout () ;
 
-  if (rev == 1)
+  if (rev == 1 || rev == ORANGEPI)
     device = "/dev/i2c-0" ;
   else
     device = "/dev/i2c-1" ;


### PR DESCRIPTION
OrangePI uses /dev/i2c-0, handle this correctly

Signed-off-by: Pavel Fedin <pavel_Fedin@mail.ru>