### PR TITLE
Fix gpio ISR

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -2030,7 +2030,7 @@ int wiringPiISR (int pin, int mode, void (*function)(void))
     else
       modeS = "both" ;
 
-    sprintf (pinS, "%d", bcmGpioPin) ;
+    sprintf (pinS, "%d", pin) ;
 
     if ((pid = fork ()) < 0)	// Fail
       return wiringPiFailure (WPI_FATAL, "wiringPiISR: fork failed: %s\n", strerror (errno)) ;


### PR DESCRIPTION
Gpio utility gets wpi pin number, not gpio pin number. Calling with latter leads to error.