### PR TITLE
Remove unnecessary name after struct

### DIFF
--- a/wiringPiD/drcNetCmd.h
+++ b/wiringPiD/drcNetCmd.h
@@ -40,5 +40,5 @@ struct drcNetComStruct
   uint32_t pin ;
   uint32_t cmd ;
   uint32_t data ;
-} comDat ;
+};
 


### PR DESCRIPTION
Hello,
This fixes the following build issue:

```
[Link (Dynamic)]
/usr/bin/ld: wpiExtensions.o:(.bss+0x408): multiple definition of `comDat'; drcNet.o:(.bss+0x400): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:143: libwiringPi.so.2.46] Error 1
```

`comDat` looks like an incomplete typedef but it actually declares a global variable. Twice, since it's included both in `wpiExtensions.c` and `drcNet.c`, which makes the build fail.

This removes the unneeded global var.
