### PR TITLE
fix #45: libwiringpi.so link to required libraries

### DIFF
--- a/wiringPi/Makefile
+++ b/wiringPi/Makefile
@@ -152,7 +152,7 @@ static:
 
 $(DYNAMIC):	$(OBJ)
 	$Q echo "[Link (Dynamic)]"
-	$Q $(CC) -shared -Wl,-soname,libwiringPi.so$(WIRINGPI_SONAME_SUFFIX) -o libwiringPi.so.$(VERSION) $(LIBS) $(OBJ)
+	$Q $(CC) -shared -Wl,-soname,libwiringPi.so$(WIRINGPI_SONAME_SUFFIX) -o libwiringPi.so.$(VERSION) $(OBJ) $(LIBS)
 
 .c.o:
 	$Q echo [Compile] $<


### PR DESCRIPTION
Details in #45 