### PR TITLE
Add second name for orangepi 5 plus

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1884,6 +1884,7 @@ void piBoardId (int * model)
 	else if (strncmp(revision, "orangepi5.",     		   10) == 0) { *model = PI_MODEL_5; }
 	else if (strncmp(revision, "orangepi5b.",     		   11) == 0) { *model = PI_MODEL_5B; }
 	else if (strncmp(revision, "orangepi5plus.",     	   14) == 0) { *model = PI_MODEL_5_PLUS; }
+	else if (strncmp(revision, "orangepi5-plus.",     	   14) == 0) { *model = PI_MODEL_5_PLUS; }
 	else if (strncmp(revision, "orangepicm4.",                 12) == 0) { *model = PI_MODEL_CM4; }
 	else if (strncmp(revision, "orangepi3b.",                  11) == 0) { *model = PI_MODEL_3B; }
 


### PR DESCRIPTION
The version of Armbian that I am using uses a different string to identify the orangepi5 plus. `orangepi5-plus.`