### PR TITLE
Make working "gpio pwm" command and wiringPiISR() function

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -3590,12 +3590,6 @@ void pwmWrite(int pin, int value) {
 		return;
 	}
 
-	if (pwmmode == 1) {
-		sunxi_pwm_set_mode(1);
-	} else {
-		sunxi_pwm_set_mode(0);
-	}
-
 	// On-Board Pin needto fix me Jim
 	if (pin < MAX_PIN_NUM) {
 		if (wiringPiMode == WPI_MODE_PINS)

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -3899,7 +3899,7 @@ int wiringPiISR (int pin, int mode, void (*function)(void))
     else
       modeS = "both" ;
 
-    sprintf (pinS, "%d", pin) ;
+    sprintf (pinS, "%d", bcmGpioPin) ;
 
     if ((pid = fork ()) < 0)	// Fail
       return wiringPiFailure (WPI_FATAL, "wiringPiISR: fork failed: %s\n", strerror (errno)) ;


### PR DESCRIPTION
Removed the sunxi_pwm_set_mode call from pwmWrite, because it kills the network adapter (on Zero 2W), writing to the wrong register:
SUNXI_PWM_CTRL_REG: [22222122]
SUNXI_PWM_PERIOD: [22222122]