### PR TITLE
Fix empty return value in orangepi_set_gpio_mode in wiringPi.c

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -7209,7 +7209,7 @@ int orangepi_set_gpio_mode(int pin, int mode)
 						printf("the pin you choose doesn't support hardware PWM\n");
 						printf("OPI:you can select wiringPi pin 33 for PWM pin\n");
 						printf("or you can use it in softPwm mode\n");
-						return;
+						exit(1);
 					}
 
 					pwm_prd_default = 150000;


### PR DESCRIPTION
Call 'return' without an actual value in a function with return value, while allowed in older GCC, is not allowed and strictly forbidden when using newer GCC

Replacing it to 'exit(1)' to stick to the similar behaviour in the  same function

This fixes the following error when compiling wiringPi with GCC 14:

```
wiringPi.c:7212:49: error: ‘return’ with no value, in function returning non-void [-Wreturn-mismatch]
 7212 |                                                 return;
      |                                                 ^~~~~~
wiringPi.c:6362:5: note: declared here
 6362 | int orangepi_set_gpio_mode(int pin, int mode)
      |     ^~~~~~~~~~~~~~~~~~~~~~
[Compile] mcp23017.c
make: *** [Makefile:85: wiringPi.o] Error 1
```