### PR TITLE
Fix error during compilation

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -8012,6 +8012,7 @@ int orangepi_digitalWrite(int pin, int value)
 			break;
 
 		case PI_MODEL_RV:
+		{
 			unsigned int dout = 0;
 			unsigned int offset = 4 * (pin / 4);
 			unsigned int shift  = 8 * (pin % 4);
@@ -8028,7 +8029,7 @@ int orangepi_digitalWrite(int pin, int value)
 			}
 
 			break;
-
+		}
 		default:
 			
 			if (bank == 11)


### PR DESCRIPTION
Fix error a label can only be part of a statement and a declaration is not a statement on build.